### PR TITLE
Make it work with GitHub Workflows v2 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,119 @@
-# rsync deployments
+# rsync deployments GitHub Action
 
-This GitHub Action deploys *everything* in `GITHUB_WORKSPACE` to a folder on a server via rsync over ssh. 
+This GitHub Action deploys your GitHub Action Workspace, totally or partially, to a remote server via rsync over ssh. 
 
 This action would usually follow a build/test action which leaves deployable code in `GITHUB_WORKSPACE`.
 
-# Required SECRETs
+## Example usage
+
+```
+name: Checkout repo master branch and deploy to production
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: contention/rsync-deployments@master
+        with:
+          USER_AND_HOST: user@example.com
+          DEST: /path/to/target
+        env:
+          DEPLOY_KEY: ${{ secrets.SSH_PRIVATE_KEY }} 
+```
+
+## Inputs
+
+### USER_AND_HOST
+
+**Mandatory**. Deployment user and host, and should be in the format: `[USER]@[HOST]`
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - # ...
+      - uses: contention/rsync-deployments@master
+        with:
+          # ...
+          USER_AND_HOST: user@domain.tld
+```
+
+### DEST
+
+**Mandatory**. Deployment destination path.
+
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - # ...
+      - uses: contention/rsync-deployments@master
+        with:
+          # ...
+          DEST: /path/to/target
+```
+
+### SRC
+
+_Optional_. Change this to deploy a smaller subset of your [GitHub workspace](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#default-environment-variables). Any value understood by `rsync` is accepted. By default, the entire workspace is deployed.
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - # ...
+      - uses: contention/rsync-deployments@master
+        with:
+          # ...
+          SRC: _site/
+```
+
+### RSYNC_OPTIONS
+
+_Optional_. Any initial/required rsync flags, as found in the _Options Summary_ section of [rsync manual](https://linux.die.net/man/1/rsync). 
+
+```yaml
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - # ...
+      - uses: contention/rsync-deployments@master
+        with:
+          # ...
+          RSYNC_OPTIONS: -avzr --delete --exclude node_modules --exclude '.git*'
+```
+
+## Required SECRET
 
 This action needs a `DEPLOY_KEY` secret variable. This should be the private key part of an ssh key pair. The public key part should be added to the authorized_keys file on the server that receives the deployment.
 
-# Required ARGs
-
-This action can receive three `ARG`s:
-
-1. The first is for any initial/required rsync flags, eg: `-avzr --delete`
-
-2. The second is for any `--exclude` flags and directory pairs, eg: `--exclude .htaccess --exclude /uploads/`. Use "" if none required.
-
-3. The third is for the deployment target, and should be in the format: `[USER]@[HOST]:[PATH]`
-
-# Example usage
-
+```yaml
+jobs:
+  # ...
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - # ...
+      - uses: contention/rsync-deployments@master
+        with:
+          # ...
+        env:
+          DEPLOY_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 ```
-workflow "All pushes" {
-  on = "push"
-  resolves = ["Deploy to Staging"]
-}
 
-action "Deploy to Staging" {
-  uses = "contention/action-rsync-deploy@master"
-  secrets = ["DEPLOY_KEY"]
-  args = ["-avzr --delete", "--exclude .htaccess --exclude /uploads/", "user@server.com:/srv/myapp/public/htdocs/"]
-} 
-```
+In this example, it is expected you create a new repo `Settings › Secrets` named `SSH_PRIVATE_KEY`, with the content of a private key, with access to the remote host you want to deploy to.
+
 
 ## Disclaimer
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,4 +10,4 @@ chmod 600 "$SSH_PATH/deploy_key"
 
 
 # Do deployment
-sh -c "rsync $1 -e 'ssh -i $SSH_PATH/deploy_key -o StrictHostKeyChecking=no' $2 $GITHUB_WORKSPACE/ $3"
+sh -c "rsync ${INPUT_RSYNC_OPTIONS} -e 'ssh -i $SSH_PATH/deploy_key -o StrictHostKeyChecking=no' $GITHUB_WORKSPACE/ ${INPUT_RSYNC_TARGET}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,4 +10,4 @@ chmod 600 "$SSH_PATH/deploy_key"
 
 
 # Do deployment
-sh -c "rsync ${INPUT_RSYNC_OPTIONS} -e 'ssh -i $SSH_PATH/deploy_key -o StrictHostKeyChecking=no' $GITHUB_WORKSPACE/ ${INPUT_RSYNC_TARGET}"
+sh -c "rsync ${INPUT_RSYNC_OPTIONS} -e 'ssh -i $SSH_PATH/deploy_key -o StrictHostKeyChecking=no' $GITHUB_WORKSPACE${INPUT_RSYNC_BASEDIR:-"/"} ${INPUT_RSYNC_TARGET}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,4 +10,4 @@ chmod 600 "$SSH_PATH/deploy_key"
 
 
 # Do deployment
-sh -c "rsync ${INPUT_RSYNC_OPTIONS} -e 'ssh -i $SSH_PATH/deploy_key -o StrictHostKeyChecking=no' $GITHUB_WORKSPACE${INPUT_RSYNC_BASEDIR:-"/"} ${INPUT_RSYNC_TARGET}"
+sh -c "rsync ${INPUT_RSYNC_OPTIONS} -e 'ssh -i $SSH_PATH/deploy_key -o StrictHostKeyChecking=no' $GITHUB_WORKSPACE/${INPUT_SRC:-""} ${INPUT_USER_AND_HOST}:${INPUT_DEST}"


### PR DESCRIPTION
Sample config:

```yml
name: Deploy to production

on:
  push:
    branches:
      - master

jobs:
  deploy:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@master
      - uses: contention/rsync-deployments@master
        with:
          USER_AND_HOST: user@example.com
          DEST: /path/to/target
          SRC: public/
          RSYNC_OPTIONS: -avzr --delete --exclude node_modules --exclude '.git*'
        env:
          DEPLOY_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
```

It accepts 3 arguments:

- `USER_AND_HOST` (mandatory): remote hostname and user (_à la_ `user@host.tld`)
- `DEST` (mandatory): remote host destination path
- `SRC` (optional): blank by default (so to say, `$GITHUB_WORKSPACE/$SRC`) — useful when something has been generated in a subfolder in a previous action (eg: `_site/` or `public/` with static site generators like Jekyll or Hugo);
- `RSYNC_OPTIONS` (optional): additional options to pass to the `rsync` command;

